### PR TITLE
adding Athabasca Oil Sands Well Dataset McMurray/Wabiskaw to dataset section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Awesome software projects sub-categorized by focus.
 - [World Stress Map](http://www.world-stress-map.org/) – A global compilation of information on the crustal present-day stress field 
 - [NOPIMS](https://nopims.dmp.wa.gov.au/nopims/) - Open petroleum geoscience data from Western Australia made available by the Australian Government
 - [UKOilandGasData](https://www.ukoilandgasdata.com/) - Open petroleum geoscience data from the UK Government (free registration required)
+- [Athabasca Oil Sands Data McMurray/Wabiskaw Oil Sands Deposit](http://ags.aer.ca/publications/SPE_006.html) - Database of well logs and stratigraphic picks for 2193 wells, including about 750 wells that have core analyses with facies. 
 
 | ▲ [Top](#awesome-open-geoscience-) |
 | --- |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Awesome software projects sub-categorized by focus.
 - [World Stress Map](http://www.world-stress-map.org/) – A global compilation of information on the crustal present-day stress field 
 - [NOPIMS](https://nopims.dmp.wa.gov.au/nopims/) - Open petroleum geoscience data from Western Australia made available by the Australian Government
 - [UKOilandGasData](https://www.ukoilandgasdata.com/) - Open petroleum geoscience data from the UK Government (free registration required)
-- [Athabasca Oil Sands Data McMurray/Wabiskaw Oil Sands Deposit](http://ags.aer.ca/publications/SPE_006.html) - Database of well logs and stratigraphic picks for 2193 wells, including about 750 wells that have core analyses with facies. 
+- [Athabasca Oil Sands Well Dataset McMurray/Wabiskaw](http://ags.aer.ca/publications/SPE_006.html) - Well logs and stratigraphic picks for 2193 wells, including 750 with lithofacies, from Alberta, Canada. 
 
 | ▲ [Top](#awesome-open-geoscience-) |
 | --- |


### PR DESCRIPTION
Added a large well dataset that includes stratigraphic picks to the dataset section. The reason this dataset is awesome is it has a large number of stratigraphic picks from the same depositional system. Most well log open-datasets do not have stratigraphic picks. 

[Athabasca Oil Sands Well Dataset McMurray/Wabiskaw](http://ags.aer.ca/publications/SPE_006.html) - Well logs and stratigraphic picks for 2193 wells, including 750 with lithofacies, from Alberta, Canada. 

