### PR TITLE
Fix vtki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Awesome software projects sub-categorized by focus.
 - [Colorcet](https://github.com/pyviz/colorcet)  – ![Python](media/icon/python.png) Perceptual colormaps
 - [cmocean](https://matplotlib.org/cmocean/) – ![Python](media/icon/python.png) MatPlotLib collection of perceptual colormaps for oceanography
 - [PVGeo](https://github.com/OpenGeoVis/PVGeo) – [![Python](media/icon/python.png)](https://pypi.org/project/PVGeo/) [![ParaView](media/icon/paraview.png)](https://www.paraview.org) Data and model visualization in ParaView and Visualization Toolkit (VTK) via `vtki`
-- [vtki](https://docs.vtki.org/en/latest/) – ![Python](media/icon/python.png) Streamlined interface for the Visualization Toolkit (VTK)
+- [vtki](http://www.vtki.org) – ![Python](media/icon/python.png) Streamlined interface for the Visualization Toolkit (VTK)
 - [omfvtk](https://omfvtk.readthedocs.io/en/latest/) – ![Python](media/icon/python.png) Visualization Toolkit (VTK) interface for the [Open Mining Format (omf)](#miscellaneous) package
 ### Platforms
 - [OpendTect](https://dgbes.com/index.php/software#free) – Seismic interpretation package

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Awesome software projects sub-categorized by focus.
 - [Colorcet](https://github.com/pyviz/colorcet)  – ![Python](media/icon/python.png) Perceptual colormaps
 - [cmocean](https://matplotlib.org/cmocean/) – ![Python](media/icon/python.png) MatPlotLib collection of perceptual colormaps for oceanography
 - [PVGeo](https://github.com/OpenGeoVis/PVGeo) – [![Python](media/icon/python.png)](https://pypi.org/project/PVGeo/) [![ParaView](media/icon/paraview.png)](https://www.paraview.org) Data and model visualization in ParaView and Visualization Toolkit (VTK) via `vtki`
-- [vtki](http://docs.vtki.org) – ![Python](media/icon/python.png) Streamlined interface for the Visualization Toolkit (VTK)
-- [omfvtk](https://omfvtk.readthedocs.io/en/latest/) – ![Python](media/icon/python.png) Visualization Toolkit (VTK) interface for the [Open Mining Format (omf)](#miscellaneous) package
+- [vtki](https://github.com/vtkiorg/vtki) – ![Python](media/icon/python.png) Streamlined interface for the Visualization Toolkit (VTK)
+- [omfvtk](https://github.com/OpenGeoVis/omfvtk) – ![Python](media/icon/python.png) Visualization Toolkit (VTK) interface for the [Open Mining Format (omf)](#miscellaneous) package
 ### Platforms
 - [OpendTect](https://dgbes.com/index.php/software#free) – Seismic interpretation package
 - [RINGMesh](https://github.com/ringmesh/RINGMesh) – ![C++](media/icon/cplusplus.png) Mesh manipulation of geological models

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Awesome software projects sub-categorized by focus.
 - [Colorcet](https://github.com/pyviz/colorcet)  – ![Python](media/icon/python.png) Perceptual colormaps
 - [cmocean](https://matplotlib.org/cmocean/) – ![Python](media/icon/python.png) MatPlotLib collection of perceptual colormaps for oceanography
 - [PVGeo](https://github.com/OpenGeoVis/PVGeo) – [![Python](media/icon/python.png)](https://pypi.org/project/PVGeo/) [![ParaView](media/icon/paraview.png)](https://www.paraview.org) Data and model visualization in ParaView and Visualization Toolkit (VTK) via `vtki`
-- [vtki](http://www.vtki.org) – ![Python](media/icon/python.png) Streamlined interface for the Visualization Toolkit (VTK)
+- [vtki](http://docs.vtki.org) – ![Python](media/icon/python.png) Streamlined interface for the Visualization Toolkit (VTK)
 - [omfvtk](https://omfvtk.readthedocs.io/en/latest/) – ![Python](media/icon/python.png) Visualization Toolkit (VTK) interface for the [Open Mining Format (omf)](#miscellaneous) package
 ### Platforms
 - [OpendTect](https://dgbes.com/index.php/software#free) – Seismic interpretation package


### PR DESCRIPTION
**Project name:** `vtki`

**Project website/repository:** http://docs.vtki.org and https://github.com/vtkiorg/vtki

We recently had to migrate `vtki` to GH-pages from readthedocs so some web addresses broke. This fixes the issue
