### PR TITLE
Include `emg3d` within `empymod`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Awesome software projects sub-categorized by focus.
 - [HyVR](https://github.com/driftingtides/hyvr) – ![Python](media/icon/python.png) 3-D anisotropic subsurface models based on geological concepts that can be used with groundwater flow simulators (e.g., [ModFlow](#simulation-and-modelling))
 - [Landlab](https://github.com/landlab/landlab) – ![Python](media/icon/python.png) Simulate surface processes using a large suite of existing interoperable process components (landscape evolution, sediment dynamics, surface hydrology, ecohydrology), exensible by own modules
 - [pyGeoPressure](https://pygeopressure.readthedocs.io/en/latest/) – ![Python](media/icon/python.png) Pore pressure prediction using well log data and seismic velocity data
-- [empymod](https://empymod.github.io) – ![Python](media/icon/python.png) Full 3D electromagnetic modeller for 1D VTI media
+- [empymod](https://empymod.github.io) – ![Python](media/icon/python.png) Controlled-source electromagnetic modellers for layered (`empymod`) and three-dimensional (`emg3d`) anisotropic media
 - [PyLops](https://pylops.readthedocs.io/en/latest/) – ![Python](media/icon/python.png) Linear Operators with some geophysics/seismic modules (e.g., pre- and post-stack AVO inversion, deconvolution, Marchenko redatuming, Radon filtering)
 ### Reservoir Engineering
 - [libres](https://github.com/equinor/libres) – ![Python](media/icon/python.png) Tool for managing an ensemble of reservoir models


### PR DESCRIPTION
Generalized the description of `empymod` to accommodate also the recently released `emg3d` multigrid solver. If it is preferred to not do that, and have two separate ones, let me know.

Project name: emg3d
Project website/repository: https://empymod.github.io
License: Apache v2.0



