### PR TITLE
Update .travis.yml to fix awesome_bot link verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: ruby
 rvm: 2.4.1
 before_script: gem install awesome_bot

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: ruby
 rvm: 2.4.1
 before_script: gem install awesome_bot
 script: awesome_bot --skip-save-results README.md --white-list travis-ci --allow 503
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: ruby
 rvm: 2.4.1
 before_script: gem install awesome_bot
 script: awesome_bot --skip-save-results README.md --white-list travis-ci --allow 503
-


### PR DESCRIPTION
As first reported in https://github.com/Open-Environmental-Science/awesome-open-hydrology, the awesome_bot needs up to date root certificates to be able to verify links properly. The default Travis Ubuntu release (16.04) is no longer updated.

This bumps travis-ci to a newer Ubuntu version to fix the problem.

