### PR TITLE
Update RINGMesh status

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Awesome software projects sub-categorized by focus.
 - [omfvista](https://github.com/OpenGeoVis/omfvista) – ![Python](media/icon/python.png) PyVista interface for the [Open Mining Format (omf)](#miscellaneous) package
 ### Platforms
 - [OpendTect](https://dgbes.com/index.php/software#free) – Seismic interpretation package, ![C++](media/icon/cplusplus.png) source code available at https://github.com/OpendTect/OpendTect
-- [RINGMesh](https://github.com/ringmesh/RINGMesh) – ![C++](media/icon/cplusplus.png) Mesh manipulation of geological models
 - [QGIS](http://www.qgis.com/) – GIS platform to visualize, manage, edit, analyse data, and compose printable maps
 - [Pangeo](https://pangeo.io/) – ![Python](media/icon/python.png) A community platform for Big Data geoscience built on top of the open source scientific python ecosystem
 - [OpenGeode](https://github.com/Geode-solutions/OpenGeode) – ![C++](media/icon/cplusplus.png) Representation and manipulation of geological models


### PR DESCRIPTION
RINGMesh is no longer under development and has been industrialized in OpenGeode (already in the list). 
Reference from their website: 
![image](https://user-images.githubusercontent.com/3213882/86442967-d50fdd80-bd0e-11ea-9732-7a572e23e7c4.png)

Should we remove it from the list?