### PR TITLE
Move to Github Actions, using lychee link checker

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,0 +1,12 @@
+on: push
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: lychee Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.0.8
+      - name: Fail if there were link errors
+        run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 jobs:
   linkChecker:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-dist: bionic
-language: ruby
-rvm: 2.4.1
-before_script: gem install awesome_bot
-script: awesome_bot --skip-save-results README.md --white-list travis-ci --allow 503 --white-list "https://reproducibility.org/wiki/Installation", "https://reproducibility.org", "https://wiki.seg.org/wiki/Open_data"

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Awesome software projects sub-categorized by focus.
 ## Data Repositories
 - [Poseidon NW Australia](https://drive.google.com/drive/folders/0B7brcf-eGK8Cbk9ueHA0QUU4Zjg) – Interpreted 3D seismic (32bit) including reports and well logs
 - [World Stress Map](http://www.world-stress-map.org/) – A global compilation of information on the crustal present-day stress field
-- [NOPIMS](https://nopims.dmp.wa.gov.au/nopims/) – Open petroleum geoscience data from Western Australia made available by the Australian Government
+- [NOPIMS](http://www.ga.gov.au/nopims) – Open petroleum geoscience data from Western Australia made available by the Australian Government
 - [UK National Data Repository](https://ndr.ogauthority.co.uk/) – Open petroleum geoscience data from the UK Government (free registration required)
 - [Athabasca Oil Sands Well Dataset McMurray/Wabiskaw](https://ags.aer.ca/publication/spe-006) – Well logs and stratigraphic picks for 2193 wells, including 750 with lithofacies, from Alberta, Canada
 - [ICGEM](http://icgem.gfz-potsdam.de/home) – Hosts gravity field spherical harmonic models and provides a webservice for generating grids of gravity functionals (geoid, gravity anomaly, vertical derivatives, etc)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Awesome software projects sub-categorized by focus.
 - [Poseidon NW Australia](https://drive.google.com/drive/folders/0B7brcf-eGK8Cbk9ueHA0QUU4Zjg) – Interpreted 3D seismic (32bit) including reports and well logs
 - [World Stress Map](http://www.world-stress-map.org/) – A global compilation of information on the crustal present-day stress field
 - [NOPIMS](https://nopims.dmp.wa.gov.au/nopims/) – Open petroleum geoscience data from Western Australia made available by the Australian Government
-- [UK National Data Repository](https://ndr.ogauthority.co.uk/dp/controller/PLEASE_LOGIN_PAGE) – Open petroleum geoscience data from the UK Government (free registration required)
+- [UK National Data Repository](https://ndr.ogauthority.co.uk/) – Open petroleum geoscience data from the UK Government (free registration required)
 - [Athabasca Oil Sands Well Dataset McMurray/Wabiskaw](https://ags.aer.ca/publication/spe-006) – Well logs and stratigraphic picks for 2193 wells, including 750 with lithofacies, from Alberta, Canada
 - [ICGEM](http://icgem.gfz-potsdam.de/home) – Hosts gravity field spherical harmonic models and provides a webservice for generating grids of gravity functionals (geoid, gravity anomaly, vertical derivatives, etc)
 - [TerraNubis](https://terranubis.com/datalist/free/) – The new _Open Seismic Repository_, includes the classic F3 and Penobscot seismic volumes (which both also have wells and other data assets).


### PR DESCRIPTION
This PR would migrate to use Github Actions instead of Travis CI, and uses the [lychee link checker](https://github.com/lycheeverse/lychee) inside the workflow.

As a first cut on #160, this PR does not address the issue of reducing frequency of link checking, or opening an issue with broken links. However, it appears that [the action readily supports this idea](https://github.com/lycheeverse/lychee-action#usage), so could be something to add next.

PR removes the Travis build file, so the status badge on the page will need to be updated once the badge url is available (after the first build I guess). 

[EXAMPLE OUTPUT](https://github.com/amoodie/awesome-open-geoscience/runs/3000018405?check_suite_focus=true)