### PR TITLE
Update .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,4 @@
 https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fsoftwareunderground%2Fawesome-open-geoscience
 https://geoscience.data.qld.gov.au
+https://opensource.org/license/lgpl-license-html
+https://opensource.org/licenses/gpl-license 


### PR DESCRIPTION
Links to OSI (Open Source Institute) website are failing as too many attempts to visit too many OSI pages (which hold license references) are occurring quickly. 

Given OSI is going to be around for quite a while likely, I'm ignoring some of this license links
