### PR TITLE
Update link_checker.yml

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.0.8
+        uses: lycheeverse/lychee-action@v2
       - name: Fail if there were link errors
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,3 +2,7 @@ https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fsoftwa
 https://geoscience.data.qld.gov.au
 https://opensource.org/license/lgpl-license-html
 https://opensource.org/licenses/gpl-license 
+https://reproducibility.org/wiki/Installation
+https://wiki.seg.org/wiki/Open_data
+https://www.gnu.org/licenses/license-list.html#NonFreeDocumentationLicenses
+https://www.gnu.org/licenses/license-list.html


### PR DESCRIPTION
Upgrading from version 1.1.8 of link checked to version 2 to see if that deals with github depreciation mentioned [here](https://github.com/softwareunderground/awesome-open-geoscience/actions/runs/11414756448/job/31764044208#step:5:5) where it says "Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"
