### PR TITLE
Add geo-utils-cpp to Geospatial

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Awesome software projects sub-categorized by focus.
 - [bm_geostat_process](https://github.com/pemn/bm_geostat_process) - ![Python](media/icon/python.png) open source workflow for geostatistics block models
 ### Geospatial
 - [Generic Mapping Tools (GMT)](https://www.generic-mapping-tools.org) – ![C](media/icon/c.png)  About 80 command-line tools for manipulating geographic and Cartesian data sets.
+- [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) – ![C++](media/icon/cplusplus.png) Spherical (lat/lng) geometry: distance, bearing, area, point-in-polygon.
 - [geonotebook](https://github.com/OpenGeoscience/geonotebook) – ![Python](media/icon/python.png) Jupyter notebook extension for geospatial visualization and analysis developed by NASA.
 - [GeoPHP](https://geophp.net) – ![PHP](media/icon/php.png) Geospatial library that works with many formats.
 - [GRASS-GIS](#platforms) – GIS platform, see [Platforms](#platforms).


### PR DESCRIPTION
Adds [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) — a header-only
C++17 library for spherical (lat/lng) geometry on Earth coordinates:
distance, bearing, polygon area, point-in-polygon, and path proximity.

- License: Apache-2.0
- No runtime dependencies
- C++17, CMake 3.14+
- CI on Linux (gcc/clang), macOS, Windows; downstream `find_package`
  smoke-tested on all three

Inserted in **Software → Geospatial**, alphabetically between
`Generic Mapping Tools (GMT)` and `geonotebook`. Used the section's
existing entry format: en-dash separator, `![C++](media/icon/cplusplus.png)`
language icon, short description ending in a period. No new section
needed; ToC unchanged. Searched for duplicates — none found.

> Note: this PR was originally opened as `geo-utils`; the project was
> renamed to `geo-utils-cpp` to avoid a Repology naming conflict
> (see gistrec/geo-utils-cpp#11). The branch has been force-pushed
> to use the new name.