### PR TITLE
Add superposed-folds to Structural Geology

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Awesome software projects sub-categorized by focus.
 - [OpenStereo](https://github.com/spamlab-iee/os) – ![Python](media/icon/python.png) An open source, cross-platform structural geology analysis software.
 - [Stress_state_plot](https://github.com/mkondratyev85/stress_state_plot) – ![Python](media/icon/python.png) An open source structural geology package for visualisation of a given stess-state via matplotlib.
 - [Romsa-py](https://github.com/bciscato/romsa-py) – ![Python](media/icon/python.png) ROMSA (Right Dihedra Method Stress Analysis) is a high-performance Python tool for determining paleostress orientations from fault-slip data.
+- [superposed-folds](https://github.com/MadsLorentzen/superposed-folds) – ![Python](media/icon/python.png) Interactive Streamlit playground and Python library for superposed folds, implementing the Ramsay & Lisle (2000) plane-strain equations and the Grasemann et al. (2004) classification, ported from Martin Schöpfer's UCD papermodels.
 ### Visualization
 - [cmocean](https://matplotlib.org/cmocean) – ![Python](media/icon/python.png) MatPlotLib collection of perceptual colormaps for oceanography.
 - [Colorcet](https://github.com/holoviz/colorcet)  – ![Python](media/icon/python.png) Perceptual colormaps.


### PR DESCRIPTION
Adds a one-line entry under `### Structural Geology` for **superposed-folds**:
https://github.com/MadsLorentzen/superposed-folds

A small Python port of Martin Schöpfer's MATLAB superposed-folding papermodels at the UCD Fault Analysis Group. MIT licensed. Implements the Ramsay & Lisle (2000) plane-strain equations and all 21 Grasemann et al. (2004) presets, with an interactive Streamlit app (3D fold stack, 2D interference map, stereonet).

The original MATLAB resource was surfaced via the Software Underground Mattermost; the port keeps a prominent link back to the UCD page in the README, the in-app references panel, and the CITATION file.