### PR TITLE
Link superposed-folds entry to archived UCD papermodels page

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Awesome software projects sub-categorized by focus.
 - [OpenStereo](https://github.com/spamlab-iee/os) – ![Python](media/icon/python.png) An open source, cross-platform structural geology analysis software.
 - [Stress_state_plot](https://github.com/mkondratyev85/stress_state_plot) – ![Python](media/icon/python.png) An open source structural geology package for visualisation of a given stess-state via matplotlib.
 - [Romsa-py](https://github.com/bciscato/romsa-py) – ![Python](media/icon/python.png) ROMSA (Right Dihedra Method Stress Analysis) is a high-performance Python tool for determining paleostress orientations from fault-slip data.
-- [superposed-folds](https://github.com/MadsLorentzen/superposed-folds) – ![Python](media/icon/python.png) Interactive Streamlit playground and Python library for superposed folds, implementing the Ramsay & Lisle (2000) plane-strain equations and the Grasemann et al. (2004) classification, ported from Martin Schöpfer's UCD papermodels.
+- [superposed-folds](https://github.com/MadsLorentzen/superposed-folds) – ![Python](media/icon/python.png) Interactive Streamlit playground and Python library for superposed folds, implementing the Ramsay & Lisle (2000) plane-strain equations and the Grasemann et al. (2004) classification, ported from Martin Schöpfer's [UCD papermodels](https://web.archive.org/web/20230513083527/https://www.fault-analysis-group.ucd.ie/SuperPosedFolds/Superposed_PM_Index.html).
 ### Visualization
 - [cmocean](https://matplotlib.org/cmocean) – ![Python](media/icon/python.png) MatPlotLib collection of perceptual colormaps for oceanography.
 - [Colorcet](https://github.com/holoviz/colorcet)  – ![Python](media/icon/python.png) Perceptual colormaps.


### PR DESCRIPTION
## Summary
- The `superposed-folds` entry mentions "Martin Schöpfer's UCD papermodels" but the original UCD Fault Analysis Group page is currently unreachable.
- This wraps that text in a link to the 2023-05-13 Wayback Machine snapshot so readers can still reach the original resource until the UCD page is restored.

## Test plan
- [x] Verified the archive URL resolves and renders the original Superposed Folding Papermodels index page.
- [x] No other entries or formatting touched; only the single line at line 171 changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)