### PR TITLE
Add GroundwaterCast (groundwater-level forecasting) to Simulation and Modelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Awesome software projects sub-categorized by focus.
 - [Fatiando a Terra](https://github.com/fatiando) – ![Python](media/icon/python.png) Modelling and inversion in geophysics.
 - [GemPy](https://github.com/cgre-aachen/gempy) – ![Python](media/icon/python.png) 3-D structural geological modelling software with implicit modelling and support for stochastic modelling.
 - [GeoPhyInv](https://github.com/pawbz/GeoPhyInv.jl) – Julia Toolbox for Geophysical Modeling and Inverse Problems.
+- [GroundwaterCast](https://github.com/dominicm2023/groundwatercast-uk) – ![Python](media/icon/python.png) Open, reproducible pipeline publishing daily probabilistic groundwater-level forecasts for 1,300+ monitored boreholes in England, driving per-borehole calibrated Pastas models with ECMWF ensemble rainfall.
 - [HyVR](https://github.com/driftingtides/hyvr) – ![Python](media/icon/python.png) 3-D anisotropic subsurface models based on geological concepts that can be used with groundwater flow simulators (e.g., [ModFlow](#simulation-and-modelling)).
 - [Landlab](https://github.com/landlab/landlab) – ![Python](media/icon/python.png) Simulate surface processes using a large suite of existing interoperable process components (landscape evolution, sediment dynamics, surface hydrology, ecohydrology), exensible by own modules.
 - [LoopStructural](https://github.com/Loop3D/LoopStructural) – ![Python](media/icon/python.png) an open-source 3D structural geological modelling library.


### PR DESCRIPTION
Adds [GroundwaterCast](https://github.com/dominicm2023/groundwatercast-uk) alphabetically to Simulation and Modelling: an open, reproducible pipeline publishing daily probabilistic groundwater-level forecasts for 1,300+ monitored boreholes in England — per-borehole calibrated Pastas transfer-function models (Pastas is already on this list) driven by ECMWF ensemble rainfall, on fully open data (EA hydrology OGL, ECMWF Open Data, Copernicus ERA5/SEAS5). MIT licensed, in daily operation at https://groundwatercast.com.