### PR TITLE
Add K3D-jupyter to Visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Awesome software projects sub-categorized by focus.
 - [PVGeo](https://github.com/OpenGeoVis/PVGeo) – [![Python](media/icon/python.png)](https://pypi.org/project/PVGeo) [![ParaView](media/icon/paraview.png)](https://www.paraview.org) Data and model visualization in ParaView and Visualization Toolkit (VTK) via PyVista.
 - [GeoVista](https://github.com/bjlittle/geovista) – ![Python](media/icon/python.png) Cartographic rendering and mesh analytics powered by PyVista.
 - [Digitize Heatmap](https://github.com/RyanFu008/digitize-heatmap) – Get numerical data from a heatmap from a PDF format.
+- [K3D-jupyter](https://github.com/K3D-tools/K3D-jupyter) – ![Python](media/icon/python.png) 3D visualization in Jupyter notebooks: volumes, isosurfaces, point clouds and streamlines from NumPy arrays.
 ### Platforms
 - [GRASS-GIS](https://grass.osgeo.org) – GIS platform for vector and raster geospatial data management, geoprocessing, spatial modelling and visualization, ![C](media/icon/c.png) ![C++](media/icon/cplusplus.png) source code available at [github](https://github.com/OSGeo/grass).
 - [OpendTect](https://dgbes.com/software/opendtect) – Seismic interpretation package, ![C++](media/icon/cplusplus.png) source code available at [github](https://github.com/OpendTect/OpendTect).


### PR DESCRIPTION
__Project name:__ K3D-jupyter

__Project website/repository:__ https://github.com/K3D-tools/K3D-jupyter (docs: https://k3d-jupyter.org)

__License:__ MIT

__Submission type:__ New Software Project

## Checklist for all pull requests:

- [x] Project is `certified awesome`
- [x] The project is open-source and accessible.
- [x] Searched the existing entries to make sure this is not a duplicate.
- [x] Contains only a single addition.
- [x] Added the link to the bottom of the relevant category. — last line of `### Visualization`, after `Digitize Heatmap`.
- [x] Created a new category only if necessary. — no new category.
- [x] Add icon from the `media/icon/` folder if applicable. — `![Python](media/icon/python.png)`.
- [x] Checked spelling and grammar.
- [x] Removed trailing whitespace and periods.
- [x] Confirm the dash – is not a minus -. — U+2013, matching the neighbouring entries.
- [x] Used title-casing (AP style) for project name.

### Checklist for new software projects:

- [x] Link the code repository rather than the website/documentation
- [x] Installation instructions present — `pip install k3d` / `conda install -c conda-forge k3d`.
- [x] Tests and CI running — pytest plus a visual-regression suite in GitHub Actions.

---

WebGL 3D plotting widget for Jupyter: volumes, isosurfaces, meshes, voxels, point clouds and streamlines, from plain NumPy arrays. MIT, ~1k stars, ~92k PyPI downloads/month, 237k on conda-forge.

Geoscience relevance: seismic and gridded volumes, terrain and LiDAR point clouds, and flow streamlines. It also reads VTK objects directly, so PyVista/VTK pipelines feed it without a conversion step, and since 3.0.0 the front end is an [anywidget](https://anywidget.dev) — the same package works in JupyterLab, Notebook, Colab and VS Code with no extension to enable.

Note on the diff: this README uses CRLF line endings, so the entry was written with CRLF to keep the diff to the single added line.

Disclosure: I maintain K3D-jupyter.
